### PR TITLE
Issue 1: Drag and Drop Release on Any Row 

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,15 +6,9 @@ import Timeline from "./components/Timeline";
 import TimelineControls from "./components/TimelineControls";
 import { JOBS } from "./data/jobs";
 import { BOSS_TIMELINES, PIXELS_PER_SECOND } from "./data/bossTimelines";
-import {
-  checkCooldownConflict,
-  getAbilitiesForSlot,
-} from "./utils/cooldownCalculations";
+import { getAbilitiesForSlot } from "./utils/cooldownCalculations";
 import { loadPlan, savePlan } from "./utils/planStorage";
-import {
-  snapToValidZone,
-  calculateValidDropZones,
-} from "./utils/validDropZones";
+import { useDragPlacement } from "./hooks/useDragPlacement";
 
 export default function MitigationPlanner() {
   const [partyComp, setPartyComp] = useState({
@@ -29,11 +23,6 @@ export default function MitigationPlanner() {
   });
 
   const [placements, setPlacements] = useState([]);
-  const [draggedAbility, setDraggedAbility] = useState(null);
-  const [draggedFrom, setDraggedFrom] = useState(null);
-  const [dragPreview, setDragPreview] = useState(null);
-  const [isDraggingOnTimeline, setIsDraggingOnTimeline] = useState(false);
-  const [dragOffset, setDragOffset] = useState(0);
   const [currentTimeline, setCurrentTimeline] = useState("dancing-green");
   const [currentPlanId, setCurrentPlanId] = useState(null);
   const [zoom, setZoom] = useState(4);
@@ -42,6 +31,21 @@ export default function MitigationPlanner() {
   const timeline = BOSS_TIMELINES[currentTimeline];
   const pixelsPerSecond = PIXELS_PER_SECOND * (zoom / 4);
   const selectedAbilities = getAbilitiesForSlot(partyComp, selectedSlot, JOBS);
+
+  const {
+    draggedAbility,
+    draggedFrom,
+    dragPreview,
+    handleDragStart,
+    handleDragOver,
+    handleDragLeave,
+    handleDropOnRow,
+  } = useDragPlacement({
+    placements,
+    setPlacements,
+    timelineDuration: timeline.duration,
+    pixelsPerSecond,
+  });
 
   // Auto-save when placements or party comp changes
   useEffect(() => {
@@ -82,153 +86,6 @@ export default function MitigationPlanner() {
     }
   };
 
-  const handleDragStart = (ability, from = "palette", clickOffset = 0) => {
-    setDraggedAbility(ability);
-    setDraggedFrom(from);
-    setDragOffset(clickOffset);
-    setIsDraggingOnTimeline(false);
-  };
-
-  const snapToGrid = (time) => {
-    return Math.round(time);
-  };
-
-  const completePlacement = (startTime, slot) => {
-    if (!draggedAbility || draggedAbility.slot !== slot) {
-      return false;
-    }
-
-    if (startTime < 0 || startTime > timeline.duration) {
-      return false;
-    }
-
-    const excludeId =
-      draggedFrom === "timeline" ? draggedAbility.placementId : null;
-    const hasConflict = checkCooldownConflict(
-      placements,
-      draggedAbility,
-      startTime,
-      excludeId
-    );
-
-    if (!hasConflict) {
-      if (draggedFrom === "palette") {
-        setPlacements([
-          ...placements,
-          {
-            ...draggedAbility,
-            startTime,
-            placementId: Date.now() + Math.random(),
-          },
-        ]);
-      } else if (draggedFrom === "timeline") {
-        setPlacements(
-          placements.map((p) =>
-            p.placementId === draggedAbility.placementId
-              ? { ...p, startTime }
-              : p
-          )
-        );
-      }
-      return true;
-    }
-    return false;
-  };
-
-  const handleDragOver = (e) => {
-    e.preventDefault();
-
-    setIsDraggingOnTimeline(true);
-
-    if (draggedAbility) {
-      const rowRect = e.currentTarget.getBoundingClientRect();
-      const x = e.clientX - rowRect.left;
-      const rawTime = Math.max(0, x / pixelsPerSecond);
-      const startTime = snapToGrid(rawTime - dragOffset);
-
-      // Only check if start time is within timeline bounds
-      if (startTime >= 0 && startTime <= timeline.duration) {
-        setDragPreview({
-          startTime,
-          slot: draggedAbility.slot,
-        });
-      } else {
-        setDragPreview(null);
-      }
-    }
-  };
-
-  const handleDragLeave = (e) => {
-    if (
-      e.currentTarget === e.target ||
-      !e.currentTarget.contains(e.relatedTarget)
-    ) {
-      setDragPreview(null);
-    }
-  };
-
-  const handleDropOnRow = (e, slot) => {
-    e.preventDefault();
-    e.stopPropagation();
-
-    const previewToUse = dragPreview;
-
-    setDragPreview(null);
-    setIsDraggingOnTimeline(false);
-
-    if (!draggedAbility) return;
-
-    if (draggedAbility.slot !== slot) {
-      setDraggedAbility(null);
-      setDraggedFrom(null);
-      setDragOffset(0);
-      return;
-    }
-
-    let startTime;
-    if (previewToUse && previewToUse.slot === slot) {
-      const excludeId =
-        draggedFrom === "timeline" ? draggedAbility.placementId : null;
-      const validZones = calculateValidDropZones(
-        placements,
-        draggedAbility,
-        timeline.duration,
-        excludeId
-      );
-      startTime = snapToValidZone(
-        previewToUse.startTime,
-        validZones,
-        draggedAbility
-      );
-    } else {
-      const rowRect = e.currentTarget.getBoundingClientRect();
-      const x = e.clientX - rowRect.left;
-      const rawTime = Math.max(0, x / pixelsPerSecond);
-      const unsnappedTime = Math.max(0, snapToGrid(rawTime - dragOffset));
-
-      // Snap to valid zones
-      const excludeId =
-        draggedFrom === "timeline" ? draggedAbility.placementId : null;
-      const validZones = calculateValidDropZones(
-        placements,
-        draggedAbility,
-        timeline.duration,
-        excludeId
-      );
-      startTime = snapToValidZone(unsnappedTime, validZones, draggedAbility);
-    }
-
-    if (completePlacement(startTime, slot)) {
-      setDraggedAbility(null);
-      setDraggedFrom(null);
-      setDragOffset(0);
-    } else {
-      setDraggedAbility(null);
-      setDraggedFrom(null);
-      setDragOffset(0);
-    }
-  };
-
   const removePlacement = (placementId) => {
     setPlacements(placements.filter((p) => p.placementId !== placementId));
   };
@@ -238,71 +95,6 @@ export default function MitigationPlanner() {
       setPlacements([]);
     }
   };
-
-  // Global drop handler
-  useEffect(() => {
-    const handleGlobalDrop = (e) => {
-      if (isDraggingOnTimeline && draggedAbility && dragPreview) {
-        e.preventDefault();
-
-        const slot = draggedAbility.slot;
-
-        // Snap the preview time to valid zones before placing
-        const excludeId =
-          draggedFrom === "timeline" ? draggedAbility.placementId : null;
-        const validZones = calculateValidDropZones(
-          placements,
-          draggedAbility,
-          timeline.duration,
-          excludeId
-        );
-        const startTime = snapToValidZone(
-          dragPreview.startTime,
-          validZones,
-          draggedAbility
-        );
-
-        setDragPreview(null);
-        setIsDraggingOnTimeline(false);
-
-        if (completePlacement(startTime, slot)) {
-          setDraggedAbility(null);
-          setDraggedFrom(null);
-          setDragOffset(0);
-        } else {
-          setDraggedAbility(null);
-          setDraggedFrom(null);
-          setDragOffset(0);
-        }
-      }
-    };
-
-    const handleGlobalDragEnd = (e) => {
-      if (draggedAbility) {
-        setDraggedAbility(null);
-        setDraggedFrom(null);
-        setDragPreview(null);
-        setIsDraggingOnTimeline(false);
-        setDragOffset(0);
-      }
-    };
-
-    document.addEventListener("drop", handleGlobalDrop);
-    document.addEventListener("dragend", handleGlobalDragEnd);
-
-    return () => {
-      document.removeEventListener("drop", handleGlobalDrop);
-      document.removeEventListener("dragend", handleGlobalDragEnd);
-    };
-  }, [
-    isDraggingOnTimeline,
-    draggedAbility,
-    dragPreview,
-    draggedFrom,
-    placements,
-    timeline.duration,
-    pixelsPerSecond,
-  ]);
 
   return (
     <div className="min-h-screen bg-gray-900 text-white p-6">

--- a/src/hooks/useDragPlacement.js
+++ b/src/hooks/useDragPlacement.js
@@ -5,6 +5,26 @@ import {
   calculateValidDropZones,
 } from "../utils/validDropZones";
 
+const snapToGrid = (time) => Math.round(time);
+
+const resolveDropTime = ({
+  time,
+  placements,
+  ability,
+  timelineDuration,
+  excludePlacementId,
+}) => {
+  const validZones = calculateValidDropZones(
+    placements,
+    ability,
+    timelineDuration,
+    excludePlacementId
+  );
+  return snapToValidZone(time, validZones, ability);
+};
+
+// Above helper functions left outside of returned hook since they do not require the state of the hook. May wish to see if it could be slightly beneficial to move others out, or these in.
+
 export function useDragPlacement({
   placements,
   setPlacements,
@@ -17,15 +37,27 @@ export function useDragPlacement({
   const [isDraggingOnTimeline, setIsDraggingOnTimeline] = useState(false);
   const [dragOffset, setDragOffset] = useState(0);
 
+  /**
+   * resetDrag - applies common setting to null for the multiple times drag is reset in this hook
+   * The following are typically also reset before this, but not consistently. 
+   * Further investigation could reveal if it's fine to add these here and remove repeats in code.
+   * setDragPreview(null);
+   * setIsDraggingOnTimeline(false);
+   */
+  const resetDrag = () => {
+    setDraggedAbility(null);
+    setDraggedFrom(null);
+    setDragOffset(0);
+  };
+
+  const getExcludePlacementId = () =>
+    draggedFrom === "timeline" ? draggedAbility.placementId : null;
+
   const handleDragStart = (ability, from = "palette", clickOffset = 0) => {
     setDraggedAbility(ability);
     setDraggedFrom(from);
     setDragOffset(clickOffset);
     setIsDraggingOnTimeline(false);
-  };
-
-  const snapToGrid = (time) => {
-    return Math.round(time);
   };
 
   const completePlacement = (startTime, slot) => {
@@ -37,8 +69,7 @@ export function useDragPlacement({
       return false;
     }
 
-    const excludeId =
-      draggedFrom === "timeline" ? draggedAbility.placementId : null;
+    const excludeId = getExcludePlacementId();
     const hasConflict = checkCooldownConflict(
       placements,
       draggedAbility,
@@ -113,55 +144,33 @@ export function useDragPlacement({
 
     if (!draggedAbility) return;
 
+    // TODO: allow dropping when mouse hovered over another slot (preview should still display in character's slot)
     if (draggedAbility.slot !== slot) {
-      setDraggedAbility(null);
-      setDraggedFrom(null);
-      setDragOffset(0);
+      resetDrag();
       return;
     }
 
-    let startTime;
+    const excludePlacementId = getExcludePlacementId();
+    let time;
     if (previewToUse && previewToUse.slot === slot) {
-      const excludeId =
-        draggedFrom === "timeline" ? draggedAbility.placementId : null;
-      const validZones = calculateValidDropZones(
-        placements,
-        draggedAbility,
-        timelineDuration,
-        excludeId
-      );
-      startTime = snapToValidZone(
-        previewToUse.startTime,
-        validZones,
-        draggedAbility
-      );
+      time = previewToUse.startTime;
     } else {
       const rowRect = e.currentTarget.getBoundingClientRect();
       const x = e.clientX - rowRect.left;
       const rawTime = Math.max(0, x / pixelsPerSecond);
-      const unsnappedTime = Math.max(0, snapToGrid(rawTime - dragOffset));
-
-      // Snap to valid zones
-      const excludeId =
-        draggedFrom === "timeline" ? draggedAbility.placementId : null;
-      const validZones = calculateValidDropZones(
-        placements,
-        draggedAbility,
-        timelineDuration,
-        excludeId
-      );
-      startTime = snapToValidZone(unsnappedTime, validZones, draggedAbility);
+      time = Math.max(0, snapToGrid(rawTime - dragOffset));
     }
 
-    if (completePlacement(startTime, slot)) {
-      setDraggedAbility(null);
-      setDraggedFrom(null);
-      setDragOffset(0);
-    } else {
-      setDraggedAbility(null);
-      setDraggedFrom(null);
-      setDragOffset(0);
-    }
+    const startTime = resolveDropTime({
+      time,
+      placements,
+      ability: draggedAbility,
+      timelineDuration,
+      excludePlacementId,
+    });
+
+    completePlacement(startTime, slot);
+    resetDrag();
   };
 
   // Global drop handler
@@ -171,44 +180,28 @@ export function useDragPlacement({
         e.preventDefault();
 
         const slot = draggedAbility.slot;
-
-        // Snap the preview time to valid zones before placing
-        const excludeId =
-          draggedFrom === "timeline" ? draggedAbility.placementId : null;
-        const validZones = calculateValidDropZones(
+        const startTime = resolveDropTime({
+          time: dragPreview.startTime,
           placements,
-          draggedAbility,
+          ability: draggedAbility,
           timelineDuration,
-          excludeId
-        );
-        const startTime = snapToValidZone(
-          dragPreview.startTime,
-          validZones,
-          draggedAbility
-        );
+          excludePlacementId:
+            draggedFrom === "timeline" ? draggedAbility.placementId : null
+        });
 
         setDragPreview(null);
         setIsDraggingOnTimeline(false);
 
-        if (completePlacement(startTime, slot)) {
-          setDraggedAbility(null);
-          setDraggedFrom(null);
-          setDragOffset(0);
-        } else {
-          setDraggedAbility(null);
-          setDraggedFrom(null);
-          setDragOffset(0);
-        }
+        completePlacement(startTime, slot);
+        resetDrag();
       }
     };
 
-    const handleGlobalDragEnd = (e) => {
+    const handleGlobalDragEnd = () => {
       if (draggedAbility) {
-        setDraggedAbility(null);
-        setDraggedFrom(null);
+        resetDrag();
         setDragPreview(null);
         setIsDraggingOnTimeline(false);
-        setDragOffset(0);
       }
     };
 

--- a/src/hooks/useDragPlacement.js
+++ b/src/hooks/useDragPlacement.js
@@ -1,0 +1,241 @@
+import { useState, useEffect } from "react";
+import { checkCooldownConflict } from "../utils/cooldownCalculations";
+import {
+  snapToValidZone,
+  calculateValidDropZones,
+} from "../utils/validDropZones";
+
+export function useDragPlacement({
+  placements,
+  setPlacements,
+  timelineDuration,
+  pixelsPerSecond,
+}) {
+  const [draggedAbility, setDraggedAbility] = useState(null);
+  const [draggedFrom, setDraggedFrom] = useState(null);
+  const [dragPreview, setDragPreview] = useState(null);
+  const [isDraggingOnTimeline, setIsDraggingOnTimeline] = useState(false);
+  const [dragOffset, setDragOffset] = useState(0);
+
+  const handleDragStart = (ability, from = "palette", clickOffset = 0) => {
+    setDraggedAbility(ability);
+    setDraggedFrom(from);
+    setDragOffset(clickOffset);
+    setIsDraggingOnTimeline(false);
+  };
+
+  const snapToGrid = (time) => {
+    return Math.round(time);
+  };
+
+  const completePlacement = (startTime, slot) => {
+    if (!draggedAbility || draggedAbility.slot !== slot) {
+      return false;
+    }
+
+    if (startTime < 0 || startTime > timelineDuration) {
+      return false;
+    }
+
+    const excludeId =
+      draggedFrom === "timeline" ? draggedAbility.placementId : null;
+    const hasConflict = checkCooldownConflict(
+      placements,
+      draggedAbility,
+      startTime,
+      excludeId
+    );
+
+    if (!hasConflict) {
+      if (draggedFrom === "palette") {
+        setPlacements([
+          ...placements,
+          {
+            ...draggedAbility,
+            startTime,
+            placementId: Date.now() + Math.random(),
+          },
+        ]);
+      } else if (draggedFrom === "timeline") {
+        setPlacements(
+          placements.map((p) =>
+            p.placementId === draggedAbility.placementId
+              ? { ...p, startTime }
+              : p
+          )
+        );
+      }
+      return true;
+    }
+    return false;
+  };
+
+  const handleDragOver = (e) => {
+    e.preventDefault();
+
+    setIsDraggingOnTimeline(true);
+
+    if (draggedAbility) {
+      const rowRect = e.currentTarget.getBoundingClientRect();
+      const x = e.clientX - rowRect.left;
+      const rawTime = Math.max(0, x / pixelsPerSecond);
+      const startTime = snapToGrid(rawTime - dragOffset);
+
+      // Only check if start time is within timeline bounds
+      if (startTime >= 0 && startTime <= timelineDuration) {
+        setDragPreview({
+          startTime,
+          slot: draggedAbility.slot,
+        });
+      } else {
+        setDragPreview(null);
+      }
+    }
+  };
+
+  const handleDragLeave = (e) => {
+    if (
+      e.currentTarget === e.target ||
+      !e.currentTarget.contains(e.relatedTarget)
+    ) {
+      setDragPreview(null);
+    }
+  };
+
+  const handleDropOnRow = (e, slot) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    const previewToUse = dragPreview;
+
+    setDragPreview(null);
+    setIsDraggingOnTimeline(false);
+
+    if (!draggedAbility) return;
+
+    if (draggedAbility.slot !== slot) {
+      setDraggedAbility(null);
+      setDraggedFrom(null);
+      setDragOffset(0);
+      return;
+    }
+
+    let startTime;
+    if (previewToUse && previewToUse.slot === slot) {
+      const excludeId =
+        draggedFrom === "timeline" ? draggedAbility.placementId : null;
+      const validZones = calculateValidDropZones(
+        placements,
+        draggedAbility,
+        timelineDuration,
+        excludeId
+      );
+      startTime = snapToValidZone(
+        previewToUse.startTime,
+        validZones,
+        draggedAbility
+      );
+    } else {
+      const rowRect = e.currentTarget.getBoundingClientRect();
+      const x = e.clientX - rowRect.left;
+      const rawTime = Math.max(0, x / pixelsPerSecond);
+      const unsnappedTime = Math.max(0, snapToGrid(rawTime - dragOffset));
+
+      // Snap to valid zones
+      const excludeId =
+        draggedFrom === "timeline" ? draggedAbility.placementId : null;
+      const validZones = calculateValidDropZones(
+        placements,
+        draggedAbility,
+        timelineDuration,
+        excludeId
+      );
+      startTime = snapToValidZone(unsnappedTime, validZones, draggedAbility);
+    }
+
+    if (completePlacement(startTime, slot)) {
+      setDraggedAbility(null);
+      setDraggedFrom(null);
+      setDragOffset(0);
+    } else {
+      setDraggedAbility(null);
+      setDraggedFrom(null);
+      setDragOffset(0);
+    }
+  };
+
+  // Global drop handler
+  useEffect(() => {
+    const handleGlobalDrop = (e) => {
+      if (isDraggingOnTimeline && draggedAbility && dragPreview) {
+        e.preventDefault();
+
+        const slot = draggedAbility.slot;
+
+        // Snap the preview time to valid zones before placing
+        const excludeId =
+          draggedFrom === "timeline" ? draggedAbility.placementId : null;
+        const validZones = calculateValidDropZones(
+          placements,
+          draggedAbility,
+          timelineDuration,
+          excludeId
+        );
+        const startTime = snapToValidZone(
+          dragPreview.startTime,
+          validZones,
+          draggedAbility
+        );
+
+        setDragPreview(null);
+        setIsDraggingOnTimeline(false);
+
+        if (completePlacement(startTime, slot)) {
+          setDraggedAbility(null);
+          setDraggedFrom(null);
+          setDragOffset(0);
+        } else {
+          setDraggedAbility(null);
+          setDraggedFrom(null);
+          setDragOffset(0);
+        }
+      }
+    };
+
+    const handleGlobalDragEnd = (e) => {
+      if (draggedAbility) {
+        setDraggedAbility(null);
+        setDraggedFrom(null);
+        setDragPreview(null);
+        setIsDraggingOnTimeline(false);
+        setDragOffset(0);
+      }
+    };
+
+    document.addEventListener("drop", handleGlobalDrop);
+    document.addEventListener("dragend", handleGlobalDragEnd);
+
+    return () => {
+      document.removeEventListener("drop", handleGlobalDrop);
+      document.removeEventListener("dragend", handleGlobalDragEnd);
+    };
+  }, [
+    isDraggingOnTimeline,
+    draggedAbility,
+    dragPreview,
+    draggedFrom,
+    placements,
+    timelineDuration,
+    pixelsPerSecond,
+  ]);
+
+  return {
+    draggedAbility,
+    draggedFrom,
+    dragPreview,
+    handleDragStart,
+    handleDragOver,
+    handleDragLeave,
+    handleDropOnRow,
+  };
+}

--- a/src/hooks/useDragPlacement.js
+++ b/src/hooks/useDragPlacement.js
@@ -144,12 +144,6 @@ export function useDragPlacement({
 
     if (!draggedAbility) return;
 
-    // TODO: allow dropping when mouse hovered over another slot (preview should still display in character's slot)
-    if (draggedAbility.slot !== slot) {
-      resetDrag();
-      return;
-    }
-
     const excludePlacementId = getExcludePlacementId();
     let time;
     if (previewToUse && previewToUse.slot === slot) {
@@ -159,6 +153,7 @@ export function useDragPlacement({
       const x = e.clientX - rowRect.left;
       const rawTime = Math.max(0, x / pixelsPerSecond);
       time = Math.max(0, snapToGrid(rawTime - dragOffset));
+      slot = previewToUse.slot; // set the slot to be placed in to be the previewed slot
     }
 
     const startTime = resolveDropTime({


### PR DESCRIPTION
## Summary
Fix and feature for 2 points from the original TODO list: https://github.com/EmilyAnsell/MitigationPlanner/issues/1

-  Allow mouse button release anywhere to drop bars where ghost image is instead of only allowing release while hovering over that job's row
- Ditto above, but for initial drag and drop from the job ability panel

Testing the drag and drop myself, I found that releasing anywhere was **not** working for me like the checklist had, but this change allows drop (on another row) to work both from the existing job's row as well as from the ability panel.

https://github.com/user-attachments/assets/4c09f2ed-676f-4e57-8f2c-1535d3700635

## Changes made
To begin work on this feature, I decided to refactor the code a bit to separate the drag functionality to a useDragPlacement hook, following the example of useTimeline hooks. This was done with the help of an agent, but I disallowed the use of changing any of the code itself beyond effectively cutting and pasting it over. On a second pass I had Claude help clean up some of the repeated code into const arrow functions. 

With the code looking a bit more orderly, I spotted and removed the section which cancelled a drop when the row being hovered over was not the chosen role's row (with the preview active), and added a line to set the slot the ability would be dropped in to be the slot as previewed.

## Testing
Testing has only been done manually with a local dev build - there is no existing unit testing. (this could be a future goal of mine to set up)